### PR TITLE
update libssl prior to ruby install

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,21 @@
 case node['platform_family']
 when 'debian'
   include_recipe 'apt'
+  packages = []
+
+  case node[:lsb][:codename]
+  when "lucid"
+      packages |= %w{ libssl0.9.8 }
+  when "precise"
+      packages |= %w{ libssl1.0.0 libssl-1.0.0-dbg }
+  else
+    packages = %w{ libssl1.0.0 libssl1.0.0-dbg }
+  end
+  packages.each do |pkg|
+      package pkg do
+        action :upgrade
+      end
+  end
 when 'rhel'
   include_recipe 'yum'
 end


### PR DESCRIPTION
if libssl is not updated before ruby-install, the chef-client run will hang in the background for `dpkg --configure -a` interactive prompt.  letting chef upgrade those packages first via the package resource fixes this issue.